### PR TITLE
Improve README documentation and issue tracker discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Software-Fungineers
 Coding Cubed will allow users to learn how to program through video game logic and puzzles. The goal of this project is to allow users to learn programming fundamentals through the familiarity of video games. 
 
-/reports/
-  - Directory full of our project reports
+## Documentation
+- User manual: `user-manual.txt`
+- Developer documentation: `developer-documentation.txt`
+
+## Bug Reporting and Known Issues
+- Report bugs on GitHub Issues: https://github.com/Mooshem/Software-Fungineers/issues
+- Known bugs and limitations are tracked in GitHub Issues.
+- Teammate note: add labels (for example `bug`, `wip`, `gameplay`, `docs`) when creating issues.
+
+## Repository Layout
+- `coding-cubed/` - Godot project source files and assets
+- `reports/` - weekly project reports


### PR DESCRIPTION
## What changed
- Added a Documentation section in README.md with direct links to: 
- user-manual.txt
- developer-documentation.txt

- Added a Bug Reporting and Known Issues section linking to GitHub Issues.
- Added a short repository layout section for faster onboarding.

## Why

This improves documentation discoverability and makes it clear where users should report bugs and find known issues.

## Test checklist
- [x] Opened README.md in GitHub and verified both documentation links are visible.
- [x] Verified GitHub Issues link points to the repository issues page.
- [x] Confirmed README sections are readable and correctly formatted.

## Notes
- Follow-up: teammate will add/update issues for known bugs